### PR TITLE
Fix encoding error on Windows multi-byte environment

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -32,6 +32,7 @@ class GenerateSwaggerCode extends JavaExec {
 
     def GenerateSwaggerCode() {
         outputDir = new File(project.buildDir, 'swagger-code')
+        defaultCharacterEncoding = 'UTF-8'
     }
 
     @TaskAction

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
@@ -15,6 +15,10 @@ class GenerateSwaggerCodeHelp extends JavaExec {
     @Input
     String language
 
+    def GenerateSwaggerCodeHelp() {
+        defaultCharacterEncoding = 'UTF-8'
+    }
+
     @TaskAction
     @Override
     void exec() {


### PR DESCRIPTION
This pull request fixes the encoding error on Windows multi-byte environment such as `ms932` in Japanese.