### PR TITLE
Add task classes to project to omit import

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPlugin.groovy
@@ -17,6 +17,8 @@ class SwaggerGeneratorPlugin implements Plugin<Project> {
 
         project.ext.GenerateSwaggerCode = GenerateSwaggerCode
         project.ext.GenerateSwaggerDoc = GenerateSwaggerDoc
+        project.ext.GenerateSwaggerUI = GenerateSwaggerUI
+        project.ext.ValidateSwagger = ValidateSwagger
 
         project.task('generateSwaggerCode',
             type: GenerateSwaggerCode,

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPluginSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPluginSpec.groovy
@@ -17,6 +17,8 @@ class SwaggerGeneratorPluginSpec extends Specification {
         then:
         project.GenerateSwaggerCode == GenerateSwaggerCode
         project.GenerateSwaggerDoc == GenerateSwaggerDoc
+        project.GenerateSwaggerUI == GenerateSwaggerUI
+        project.ValidateSwagger == ValidateSwagger
     }
 
     def "plugin should add default tasks"() {
@@ -31,6 +33,8 @@ class SwaggerGeneratorPluginSpec extends Specification {
         then:
         project.tasks.findByName('generateSwaggerCode')
         project.tasks.findByName('generateSwaggerDoc')
+        project.tasks.findByName('generateSwaggerUI')
+        project.tasks.findByName('validateSwagger')
     }
 
     def "exception should be thrown if no dependency given in SwaggerCodegen"() {


### PR DESCRIPTION
Fix error:
```
Error:(21, 0) Could not get unknown property 'GenerateSwaggerUI' for project ':swagger:docs' of type org.gradle.api.Project.
```