### PR TITLE
Fix JSON schema not found error

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
@@ -3,6 +3,7 @@ package org.hidetake.gradle.swagger.generator
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import groovy.util.logging.Slf4j
+import io.swagger.util.Json
 import io.swagger.util.Yaml
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputFile
@@ -16,10 +17,14 @@ class ValidateSwagger extends DefaultTask {
 
     @TaskAction
     void exec() {
-        def jsonNode = Yaml.mapper().readTree(inputFile)
+        def schemaResource = ValidateSwagger.getResourceAsStream('/schema.json')
+        assert schemaResource, 'JSON schema should be exist in resource'
+
+        def schemaNode = Json.mapper().readTree(schemaResource)
         def schemaFactory = JsonSchemaFactory.byDefault()
-        def schemaResource = ValidateSwagger.getResource('/schema.json')
-        def schema = schemaFactory.getJsonSchema(schemaResource?.toString() ?: 'http://swagger.io/v2/schema.json')
+        def schema = schemaFactory.getJsonSchema(schemaNode)
+
+        def jsonNode = Yaml.mapper().readTree(inputFile)
         def report = schema.validate(jsonNode)
         def cause = Yaml.mapper()
             .enable(SerializationFeature.INDENT_OUTPUT)


### PR DESCRIPTION
Fix error:

```
* What went wrong:
Execution failed for task ':validateSwagger'.
> How did I get there??

Caused by: java.lang.IllegalStateException: How did I get there??
        at com.github.fge.jsonschema.core.util.URIUtils$2.apply(URIUtils.java:113)

Caused by: java.net.URISyntaxException: Expected scheme-specific part at index 4: jar:
        at com.github.fge.jsonschema.core.util.URIUtils$2.apply(URIUtils.java:110)
        ... 84 more
```