### PR TITLE
Skip task if no input file is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Custom generation
 -----------------
 
 The plugin adds `validateSwagger`, `generateSwaggerCode` and `generateSwaggerUI` tasks.
+A task will be skipped if no input file is given.
 
 See projects under [acceptance-test](acceptance-test) for more.
 

--- a/acceptance-test/blank-project/build.gradle
+++ b/acceptance-test/blank-project/build.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id 'org.hidetake.swagger.generator'
+}
+
+// just add the plugin for verifying default tasks should be skipped

--- a/acceptance-test/src/test/groovy/DefaultTasksSpec.groovy
+++ b/acceptance-test/src/test/groovy/DefaultTasksSpec.groovy
@@ -1,0 +1,37 @@
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultTasksSpec extends Specification {
+
+    GradleRunner runner
+
+    def setup() {
+        runner = GradleRunner.create()
+            .withProjectDir(new File('blank-project'))
+            .withPluginClasspath()
+            .forwardOutput()
+    }
+
+    @Unroll
+    def 'task #taskName should be skipped'() {
+        given:
+        runner.withArguments(taskName)
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.tasks.head().outcome == TaskOutcome.SKIPPED
+
+        where:
+        taskName << [
+            'generateSwaggerCode',
+            'generateSwaggerCodeHelp',
+            'generateSwaggerUI',
+            'validateSwagger',
+        ]
+    }
+
+}

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -34,6 +34,9 @@ class GenerateSwaggerCode extends DefaultTask {
 
     def GenerateSwaggerCode() {
         outputDir = new File(project.buildDir, 'swagger-code')
+        onlyIf {
+            inputFile
+        }
     }
 
     @TaskAction

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
@@ -16,6 +16,12 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
     @Input
     String language
 
+    def GenerateSwaggerCodeHelp() {
+        onlyIf {
+            language
+        }
+    }
+
     @TaskAction
     void exec() {
         println("Available JSON configuration for language $language:")

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
@@ -30,6 +30,9 @@ class GenerateSwaggerUI extends DefaultTask {
     def GenerateSwaggerUI() {
         outputDir = new File(project.buildDir, 'swagger-ui')
         options = [:]
+        onlyIf {
+            inputFile
+        }
     }
 
     @TaskAction

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
@@ -15,6 +15,12 @@ class ValidateSwagger extends DefaultTask {
     @InputFile
     File inputFile
 
+    def ValidateSwagger() {
+        onlyIf {
+            inputFile
+        }
+    }
+
     @TaskAction
     void exec() {
         def schemaResource = ValidateSwagger.getResourceAsStream('/schema.json')


### PR DESCRIPTION
This changes a task to be skipped if no input file is given. Useful in multi-project environment.