### PR TITLE
Add additionalProperties for GenerateSwaggerCode task

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Key           | Type              | Value                                   | De
 `configFile`  | File              | [JSON configuration file](https://github.com/swagger-api/swagger-codegen#customizing-the-generator). | None
 `templateDir` | File              | Directory containing the template.      | None
 `components`  | List of Strings   | [Components to generate](https://github.com/swagger-api/swagger-codegen#selective-generation) that is a list of `models`, `apis` and `supportingFiles`. | All components
+`additionalProperties` | Map of String, String | [Additional properties](https://github.com/swagger-api/swagger-codegen#to-generate-a-sample-client-library). | None
 
 
 ### Task type `GenerateSwaggerUI`

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -30,6 +30,9 @@ class GenerateSwaggerCode extends DefaultTask {
     File templateDir
 
     @Optional @Input
+    Map<String, String> additionalProperties
+
+    @Optional @Input
     List<String> components
 
     def GenerateSwaggerCode() {
@@ -61,7 +64,7 @@ class GenerateSwaggerCode extends DefaultTask {
         }
     }
 
-    private List<String> buildOptions() {
+    List<String> buildOptions() {
         def options = []
         options << 'generate'
         options << '-l' << language
@@ -75,6 +78,11 @@ class GenerateSwaggerCode extends DefaultTask {
         }
         if (templateDir) {
             options << '-t' << templateDir.path
+        }
+        if (additionalProperties) {
+            options << '--additional-properties' << additionalProperties.collect { key, value ->
+                "$key=$value"
+            }.join(',')
         }
         options
     }

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeSpec.groovy
@@ -50,4 +50,28 @@ class GenerateSwaggerCodeSpec extends Specification {
         e.message.contains('project directory')
     }
 
+    def "plugin should build options for Swagger Codegen"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        def options = project.with {
+            apply plugin: 'org.hidetake.swagger.generator'
+            tasks.generateSwaggerCode.language = 'java'
+            tasks.generateSwaggerCode.inputFile = new File('input')
+            tasks.generateSwaggerCode.outputDir = new File('output')
+            tasks.generateSwaggerCode.additionalProperties = [foo: 'bar', baz: 'zzz']
+            tasks.generateSwaggerCode.buildOptions()
+        }
+
+        then:
+        options == [
+            'generate',
+            '-l', 'java',
+            '-i', 'input',
+            '-o', 'output',
+            '--additional-properties', 'foo=bar,baz=zzz'
+        ]
+    }
+
 }


### PR DESCRIPTION
This adds `additionalProperties` property to pass additional properties to Swagger Codegen.