### PR TITLE
Fix error on JSON schema validation if internet connection is not available

### DIFF
--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -1,6 +1,5 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [


### PR DESCRIPTION
This pull request allows JSON schema validation without Internet connection.

Current version causes the following error if Internet connection is not available.

```
:validateSwagger FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':validateSwagger'.
> com.github.fge.jsonschema.core.exceptions.ProcessingException: fatal: unable to dereference URI "http://swagger.io/v2/schema.json#"
      level: "fatal"
      uri: "http://swagger.io/v2/schema.json#"
      exceptionMessage: "swagger.io"
```