### PR TITLE
Fix classloader to integrate codegen with Gradle logger

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerCodegenExecutor.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerCodegenExecutor.groovy
@@ -36,7 +36,7 @@ class SwaggerCodegenExecutor {
         } catch (ClassNotFoundException ignore) {
             def urls = project.configurations.swaggerCodegen.collect { jar -> jar.toURI().toURL() } as URL[]
             CLASS_CACHE.computeIfAbsent(urls) {
-                def classLoader = new URLClassLoader(urls)
+                def classLoader = new URLClassLoader(urls, project.buildscript.classLoader)
                 try {
                     Class.forName(CLASS_NAME, true, classLoader)
                 } catch (ClassNotFoundException e) {


### PR DESCRIPTION
This pull request fixes the log level of Swagger Codegen to the log level of Gradle. At default warnings and errors should be printed. See #38.

This fixes to use the classloader of build script for loading Swagger Codegen. It allows using the SLF4J bridge of Gradle logging system.