### PR TITLE
Bump plugin-publish to resolve plugin not found problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'groovy'
-    id 'com.gradle.plugin-publish' version '0.9.6'
+    id 'com.gradle.plugin-publish' version '0.9.7'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This fixes following problem:

> Could not resolve all files for configuration ':classpath'.
   > Could not find gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.5.0.
     Searched in the following locations:
         https://plugins.gradle.org/m2/gradle/plugin/org/hidetake/gradle-swagger-generator-plugin/2.5.0/gradle-swagger-generator-plugin-2.5.0.pom
         https://plugins.gradle.org/m2/gradle/plugin/org/hidetake/gradle-swagger-generator-plugin/2.5.0/gradle-swagger-generator-plugin-2.5.0.jar