### PR TITLE
Add declarative syntax for multiple sources use case

### DIFF
--- a/acceptance-test/code-generator/build.gradle
+++ b/acceptance-test/code-generator/build.gradle
@@ -8,17 +8,22 @@ repositories {
 }
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web:1.4.1.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:1.5.7.RELEASE'
     compile 'io.swagger:swagger-annotations:1.5.10'
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.2.3'
 }
 
-generateSwaggerCode {
-    language = 'spring'
-    inputFile = file("$buildDir/petstore.yaml")
-    configFile = file('config.json')
-    components = ['models', 'apis']
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        code {
+            language = 'spring'
+            configFile = file('config.json')
+            components = ['models', 'apis']
+            dependsOn validation
+        }
+    }
 }
 
-compileJava.dependsOn generateSwaggerCode
-sourceSets.main.java.srcDir generateSwaggerCode.outputDir
+compileJava.dependsOn swaggerSources.petstore.code
+sourceSets.main.java.srcDir swaggerSources.petstore.code.outputDir

--- a/acceptance-test/custom-class/build.gradle
+++ b/acceptance-test/custom-class/build.gradle
@@ -3,9 +3,13 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-generateSwaggerCode {
-    language = 'CustomGenerator'
-    inputFile = file("$buildDir/petstore.yaml")
-    configFile = file('config.json')
-    components = ['models', 'apis']
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        code {
+            language = 'CustomGenerator'
+            configFile = file('config.json')
+            components = ['models', 'apis']
+        }
+    }
 }

--- a/acceptance-test/custom-template/build.gradle
+++ b/acceptance-test/custom-template/build.gradle
@@ -10,10 +10,14 @@ dependencies {
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.2.3'
 }
 
-generateSwaggerCode {
-    language = 'spring'
-    inputFile = file("$buildDir/petstore.yaml")
-    configFile = file('config.json')
-    templateDir = file('template/server')
-    components = ['models', 'apis']
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        code {
+            language = 'spring'
+            configFile = file('config.json')
+            templateDir = file('template/server')
+            components = ['models', 'apis']
+        }
+    }
 }

--- a/acceptance-test/doc-generator/build.gradle
+++ b/acceptance-test/doc-generator/build.gradle
@@ -10,17 +10,18 @@ dependencies {
     swaggerUI 'org.webjars:swagger-ui:2.2.6'
 }
 
-generateSwaggerUI {
-    inputFile = file("$buildDir/petstore.yaml")
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        ui {
+            // Swagger UI options
+            options.docExpansion = 'full'
+            options.supportedSubmitMethods = []
 
-    // Swagger UI options
-    options.docExpansion = 'full'
-    options.supportedSubmitMethods = []
-
-    // Custom header
-    header = '''\
-        <style>#header { display: none; }</style>
-        '''.stripIndent()
+            // Custom header
+            header = '''\
+                <style>#header { display: none; }</style>
+                '''.stripIndent()
+        }
+    }
 }
-
-task build(dependsOn: generateSwaggerUI)

--- a/acceptance-test/externalize-template/build.gradle
+++ b/acceptance-test/externalize-template/build.gradle
@@ -2,14 +2,6 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-generateSwaggerCode {
-    language = 'java'
-    inputFile = file("$buildDir/petstore.yaml")
-    configFile = file('config.json')
-    templateDir = file("${resolveSwaggerTemplate.destinationDir}/resttemplate")
-    components = ['models', 'apis']
-}
-
 repositories {
     // This example assumes the swagger template is published on the Maven local repository.
     // Actually it can be external such as Nexus or Artifactory.
@@ -21,4 +13,16 @@ repositories {
 dependencies {
     swaggerTemplate 'org.hidetake:swagger-templates:1.0.0'
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.2.3'
+}
+
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        code {
+            language = 'java'
+            configFile = file('config.json')
+            templateDir = file("${resolveSwaggerTemplate.destinationDir}/resttemplate")
+            components = ['models', 'apis']
+        }
+    }
 }

--- a/acceptance-test/html-generator/build.gradle
+++ b/acceptance-test/html-generator/build.gradle
@@ -10,8 +10,12 @@ dependencies {
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.2.3'
 }
 
-generateSwaggerCode {
-    language = 'html2'
-    inputFile = file("$buildDir/petstore.yaml")
-    outputDir = file("$buildDir/swagger-html")
+swaggerSources {
+    petstore {
+        code {
+            language = 'html2'
+            inputFile = file("$buildDir/petstore.yaml")
+            outputDir = file("$buildDir/swagger-html")
+        }
+    }
 }

--- a/acceptance-test/multiple-sources/build.gradle
+++ b/acceptance-test/multiple-sources/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'org.hidetake.swagger.generator'
+    id 'java'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile 'org.springframework.boot:spring-boot-starter-web:1.5.7.RELEASE'
+    compile 'io.swagger:swagger-annotations:1.5.10'
+    swaggerCodegen 'io.swagger:swagger-codegen-cli:2.2.3'
+    swaggerUI 'org.webjars:swagger-ui:2.2.6'
+}
+
+swaggerSources {
+    petstoreV1 {
+        inputFile = file('v1-petstore.yaml')
+        code {
+            language = 'spring'
+            components = ['models', 'apis']
+            configFile = file('v1-config.json')
+        }
+        ui {
+            outputDir = file("$buildDir/docs/v1")
+        }
+    }
+    petstoreV2 {
+        inputFile = file('v2-petstore.yaml')
+        code {
+            language = 'spring'
+            components = ['models', 'apis']
+            configFile = file('v2-config.json')
+        }
+        ui {
+            outputDir = file("$buildDir/docs/v2")
+        }
+    }
+}
+
+compileJava.dependsOn swaggerSources.petstoreV1.code, swaggerSources.petstoreV2.code
+sourceSets.main.java.srcDirs swaggerSources.petstoreV1.code.outputDir, swaggerSources.petstoreV2.code.outputDir

--- a/acceptance-test/multiple-sources/v1-config.json
+++ b/acceptance-test/multiple-sources/v1-config.json
@@ -1,0 +1,8 @@
+{
+  "library": "spring-mvc",
+  "dateLibrary": "java8",
+  "hideGenerationTimestamp": true,
+  "modelPackage": "example.v1.model",
+  "apiPackage": "example.v1.api",
+  "invokerPackage": "example.v1"
+}

--- a/acceptance-test/multiple-sources/v1-petstore.yaml
+++ b/acceptance-test/multiple-sources/v1-petstore.yaml
@@ -1,0 +1,68 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore v1
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/acceptance-test/multiple-sources/v2-config.json
+++ b/acceptance-test/multiple-sources/v2-config.json
@@ -1,0 +1,8 @@
+{
+  "library": "spring-mvc",
+  "dateLibrary": "java8",
+  "hideGenerationTimestamp": true,
+  "modelPackage": "example.v2.model",
+  "apiPackage": "example.v2.api",
+  "invokerPackage": "example.v2"
+}

--- a/acceptance-test/multiple-sources/v2-petstore.yaml
+++ b/acceptance-test/multiple-sources/v2-petstore.yaml
@@ -1,0 +1,80 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore v2
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v2
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/acceptance-test/src/test/groovy/CodeGeneratorSpec.groovy
+++ b/acceptance-test/src/test/groovy/CodeGeneratorSpec.groovy
@@ -38,14 +38,16 @@ class CodeGeneratorSpec extends Specification {
         def result = runner.build()
 
         then:
-        result.task(':generateSwaggerCode').outcome == TaskOutcome.SUCCESS
-        new File(runner.projectDir, 'build/swagger-code/src/main/java/example/api/PetsApi.java').exists()
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstore/src/main/java/example/api/PetsApi.java').exists()
 
         when:
         def rerunResult = runner.build()
 
         then:
-        rerunResult.task(':generateSwaggerCode').outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        rerunResult.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.UP_TO_DATE
     }
 
     def 'build task should build the generated code'() {
@@ -60,9 +62,9 @@ class CodeGeneratorSpec extends Specification {
         new File(runner.projectDir, 'build/libs/code-generator.jar').exists()
     }
 
-    def 'generateSwaggerCodeHelp task should show help'() {
+    def 'generateSwaggerCodePetstoreHelp task should show help'() {
         given:
-        runner.withArguments('--stacktrace', 'generateSwaggerCodeHelp')
+        runner.withArguments('--stacktrace', 'generateSwaggerCodePetstoreHelp')
 
         when:
         def result = runner.build()

--- a/acceptance-test/src/test/groovy/CustomClassSpec.groovy
+++ b/acceptance-test/src/test/groovy/CustomClassSpec.groovy
@@ -26,13 +26,14 @@ class CustomClassSpec extends Specification {
         def result = runner.build()
 
         then:
-        result.task(':generateSwaggerCode').outcome == TaskOutcome.SUCCESS
-        new File(runner.projectDir, 'build/swagger-code/src/main/java/example/api/PetsApi.java').exists()
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstore/src/main/java/example/api/PetsApi.java').exists()
     }
 
-    def 'generateSwaggerCodeHelp task should show help'() {
+    def 'generateSwaggerCodePetstoreHelp task should show help'() {
         given:
-        runner.withArguments('--stacktrace', 'generateSwaggerCodeHelp')
+        runner.withArguments('--stacktrace', 'generateSwaggerCodePetstoreHelp')
 
         when:
         def result = runner.build()

--- a/acceptance-test/src/test/groovy/CustomTemplateSpec.groovy
+++ b/acceptance-test/src/test/groovy/CustomTemplateSpec.groovy
@@ -26,13 +26,14 @@ class CustomTemplateSpec extends Specification {
         def result = runner.build()
 
         then:
-        result.task(':generateSwaggerCode').outcome == TaskOutcome.SUCCESS
-        new File(runner.projectDir, 'build/swagger-code/src/main/java/example/api/PetsApi.java').exists()
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstore/src/main/java/example/api/PetsApi.java').exists()
     }
 
-    def 'generateSwaggerCodeHelp task should show help'() {
+    def 'generateSwaggerCodePetstoreHelp task should show help'() {
         given:
-        runner.withArguments('--stacktrace', 'generateSwaggerCodeHelp')
+        runner.withArguments('--stacktrace', 'generateSwaggerCodePetstoreHelp')
 
         when:
         def result = runner.build()

--- a/acceptance-test/src/test/groovy/DocGeneratorSpec.groovy
+++ b/acceptance-test/src/test/groovy/DocGeneratorSpec.groovy
@@ -17,23 +17,25 @@ class DocGeneratorSpec extends Specification {
         cleanBuildDir(runner)
     }
 
-    def 'build task should generate an Swagger UI'() {
+    def 'generateSwaggerUI task should generate an Swagger UI'() {
         given:
         placePetstoreYaml(runner, Fixture.PetstoreYaml.valid)
-        runner.withArguments('--stacktrace', 'build')
+        runner.withArguments('--stacktrace', 'generateSwaggerUI')
 
         when:
         def result = runner.build()
 
         then:
-        result.task(':generateSwaggerUI').outcome == TaskOutcome.SUCCESS
-        new File("${runner.projectDir}/build/swagger-ui/index.html").exists()
+        result.task(':generateSwaggerUI').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerUIPetstore').outcome == TaskOutcome.SUCCESS
+        new File("${runner.projectDir}/build/swagger-ui-petstore/index.html").exists()
 
         when:
         def rerunResult = runner.build()
 
         then:
-        rerunResult.task(':generateSwaggerUI').outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':generateSwaggerUI').outcome == TaskOutcome.NO_SOURCE
+        rerunResult.task(':generateSwaggerUIPetstore').outcome == TaskOutcome.UP_TO_DATE
     }
 
 }

--- a/acceptance-test/src/test/groovy/ExternalizeTemplateSpec.groovy
+++ b/acceptance-test/src/test/groovy/ExternalizeTemplateSpec.groovy
@@ -31,7 +31,8 @@ class ExternalizeTemplateSpec extends Specification {
 
         then:
         result.task(':resolveSwaggerTemplate').outcome == TaskOutcome.SUCCESS
-        result.task(':generateSwaggerCode').outcome == TaskOutcome.SUCCESS
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
     }
 
 }

--- a/acceptance-test/src/test/groovy/HtmlGeneratorSpec.groovy
+++ b/acceptance-test/src/test/groovy/HtmlGeneratorSpec.groovy
@@ -26,13 +26,14 @@ class HtmlGeneratorSpec extends Specification {
         def result = runner.build()
 
         then:
-        result.task(':generateSwaggerCode').outcome == TaskOutcome.SUCCESS
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
         new File(runner.projectDir, 'build/swagger-html/index.html').exists()
     }
 
-    def 'generateSwaggerCodeHelp task should show help'() {
+    def 'generateSwaggerCodePetstoreHelp task should show help'() {
         given:
-        runner.withArguments('--stacktrace', 'generateSwaggerCodeHelp')
+        runner.withArguments('--stacktrace', 'generateSwaggerCodePetstoreHelp')
 
         when:
         def result = runner.build()

--- a/acceptance-test/src/test/groovy/MultipleSourcesSpec.groovy
+++ b/acceptance-test/src/test/groovy/MultipleSourcesSpec.groovy
@@ -1,0 +1,127 @@
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static Fixture.cleanBuildDir
+import static Fixture.placePetstoreYaml
+
+class MultipleSourcesSpec extends Specification {
+
+    GradleRunner runner
+
+    def setup() {
+        runner = GradleRunner.create()
+            .withProjectDir(new File('multiple-sources'))
+            .withPluginClasspath()
+            .forwardOutput()
+        cleanBuildDir(runner)
+    }
+
+    def 'tasks should be added into the project'() {
+        given:
+        runner.withArguments('--stacktrace', 'tasks')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.output.contains('generateSwaggerCodePetstoreV1 -')
+        result.output.contains('generateSwaggerCodePetstoreV2 -')
+        result.output.contains('generateSwaggerUIPetstoreV1 -')
+        result.output.contains('generateSwaggerUIPetstoreV2 -')
+        result.output.contains('validateSwaggerPetstoreV1 -')
+        result.output.contains('validateSwaggerPetstoreV2 -')
+    }
+
+    def 'generateSwaggerCode task should generate sources'() {
+        given:
+        runner.withArguments('--stacktrace', 'generateSwaggerCode')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.task(':generateSwaggerCodePetstoreV1').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstoreV1/src/main/java/example/v1/api/PetsApi.java').exists()
+        result.task(':generateSwaggerCodePetstoreV2').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstoreV2/src/main/java/example/v2/api/PetsApi.java').exists()
+
+        when:
+        def rerunResult = runner.build()
+
+        then:
+        rerunResult.task(':generateSwaggerCodePetstoreV1').outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':generateSwaggerCodePetstoreV2').outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def 'build task should build the generated code'() {
+        given:
+        placePetstoreYaml(runner, Fixture.PetstoreYaml.valid)
+        runner.withArguments('--stacktrace', 'build')
+
+        when:
+        runner.build()
+
+        then:
+        new File(runner.projectDir, 'build/libs/multiple-sources.jar').exists()
+    }
+
+    @Unroll
+    def '#taskName task should show help'() {
+        given:
+        runner.withArguments('--stacktrace', taskName)
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.output.contains('CONFIG OPTIONS')
+
+        where:
+        taskName << ['generateSwaggerCodePetstoreV1Help', 'generateSwaggerCodePetstoreV2Help']
+    }
+
+    def 'generateSwaggerUI task should generate sources'() {
+        given:
+        runner.withArguments('--stacktrace', 'generateSwaggerUI')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.task(':generateSwaggerUIPetstoreV1').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/docs/v1/index.html').exists()
+        result.task(':generateSwaggerUIPetstoreV2').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/docs/v2/index.html').exists()
+
+        when:
+        def rerunResult = runner.build()
+
+        then:
+        rerunResult.task(':generateSwaggerUIPetstoreV1').outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':generateSwaggerUIPetstoreV2').outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def 'validateSwagger task should validate sources'() {
+        given:
+        runner.withArguments('--stacktrace', 'validateSwagger')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.task(':validateSwaggerPetstoreV1').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-validation-petstoreV1.yaml').exists()
+        result.task(':validateSwaggerPetstoreV2').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-validation-petstoreV2.yaml').exists()
+
+        when:
+        def rerunResult = runner.build()
+
+        then:
+        rerunResult.task(':validateSwaggerPetstoreV1').outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':validateSwaggerPetstoreV2').outcome == TaskOutcome.UP_TO_DATE
+    }
+
+}

--- a/acceptance-test/src/test/groovy/ValidatorSpec.groovy
+++ b/acceptance-test/src/test/groovy/ValidatorSpec.groovy
@@ -27,14 +27,16 @@ class ValidatorSpec extends Specification {
         def result = runner.build()
 
         then:
-        result.task(':validateSwagger').outcome == TaskOutcome.SUCCESS
-        new File("${runner.projectDir}/build/tmp/validateSwagger/report.yaml").exists()
+        result.task(':validateSwagger').outcome == TaskOutcome.NO_SOURCE
+        result.task(':validateSwaggerPetstore').outcome == TaskOutcome.SUCCESS
+        new File("${runner.projectDir}/build/swagger-validation-petstore.yaml").exists()
 
         when:
         def rerunResult = runner.build()
 
         then:
-        rerunResult.tasks.first().outcome == TaskOutcome.UP_TO_DATE
+        rerunResult.task(':validateSwagger').outcome == TaskOutcome.NO_SOURCE
+        rerunResult.task(':validateSwaggerPetstore').outcome == TaskOutcome.UP_TO_DATE
     }
 
     def 'validateSwagger task should fail due to YAML error'() {
@@ -46,7 +48,7 @@ class ValidatorSpec extends Specification {
         runner.build()
 
         then:
-        new File("${runner.projectDir}/build/tmp/validateSwagger/report.yaml").exists()
+        new File("${runner.projectDir}/build/swagger-validation-petstore.yaml").exists()
         thrown(UnexpectedBuildFailure)
 
         when:

--- a/acceptance-test/validator/build.gradle
+++ b/acceptance-test/validator/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-validateSwagger {
-    inputFile = file("$buildDir/petstore.yaml")
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+    }
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -10,11 +10,11 @@ import org.gradle.api.tasks.*
  */
 class GenerateSwaggerCode extends DefaultTask {
 
-    @Input
-    String language
-
     @SkipWhenEmpty @InputFiles
     File inputFile
+
+    @Input
+    String language
 
     @OutputDirectory
     File outputDir

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
@@ -28,7 +28,6 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
     static Task injectHelpTaskFor(GenerateSwaggerCode task) {
         task.project.task("${task.name}Help",
             description: "Displays available JSON configuration for $task",
-            dependsOn: task.dependsOn,
             group: 'help',
             type: GenerateSwaggerCodeHelp) {
             language = task.language

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
@@ -20,14 +20,13 @@ class GenerateSwaggerUI extends DefaultTask {
     File outputDir
 
     @Optional @Input
-    Map<String, Object> options
+    Map<String, Object> options = [:]
 
     @Optional @Input
     String header
 
     def GenerateSwaggerUI() {
         outputDir = new File(project.buildDir, 'swagger-ui')
-        options = [:]
     }
 
     @TaskAction

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorExtension.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorExtension.groovy
@@ -1,0 +1,22 @@
+package org.hidetake.gradle.swagger.generator
+
+import org.gradle.api.NamedDomainObjectContainer
+
+/**
+ * An extension class to provide declarative syntax.
+ *
+ * @author Hidetake Iwata
+ */
+class SwaggerGeneratorExtension {
+
+    def SwaggerGeneratorExtension(NamedDomainObjectContainer<SwaggerSource> code) {
+        this.code = code
+    }
+
+    final NamedDomainObjectContainer<SwaggerSource> code
+
+    NamedDomainObjectContainer<SwaggerSource> code(@DelegatesTo(SwaggerSource) Closure configuration) {
+        code.configure(configuration)
+    }
+
+}

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerGeneratorPlugin.groovy
@@ -12,6 +12,9 @@ class SwaggerGeneratorPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        def swaggerSources = project.container(SwaggerSource)
+        project.extensions.add('swaggerSources', swaggerSources)
+
         project.configurations.create('swaggerCodegen')
         project.configurations.create('swaggerUI')
         project.configurations.create('swaggerTemplate')
@@ -25,27 +28,52 @@ class SwaggerGeneratorPlugin implements Plugin<Project> {
             group: 'build setup',
             description: 'Resolves template files from the swaggerTemplate configuration.')
 
-        project.task('generateSwaggerCode',
-            type: GenerateSwaggerCode,
-            group: 'build',
-            description: 'Generates a source code from the swagger specification.',
-            dependsOn: 'resolveSwaggerTemplate')
+        createValidateSwagger(project)
+        createGenerateSwaggerCode(project)
+        createGenerateSwaggerUI(project)
 
-        project.task('generateSwaggerUI',
-            type: GenerateSwaggerUI,
-            group: 'documentation',
-            description: 'Generates Swagger UI from the swagger specification.')
+        swaggerSources.all {
+            def swaggerSource = delegate as SwaggerSource
+            swaggerSource.validation = createValidateSwagger(project, swaggerSource.name)
+            swaggerSource.code = createGenerateSwaggerCode(project, swaggerSource.name)
+            swaggerSource.ui = createGenerateSwaggerUI(project, swaggerSource.name)
 
-        project.task('validateSwagger',
-            type: ValidateSwagger,
-            group: 'verification',
-            description: 'Validates the swagger specification.')
+            project.tasks.validateSwagger.dependsOn(swaggerSource.validation)
+            project.tasks.generateSwaggerCode.dependsOn(swaggerSource.code)
+            project.tasks.generateSwaggerUI.dependsOn(swaggerSource.ui)
+
+            swaggerSource.validation.reportFile = new File(project.buildDir, "swagger-validation-${swaggerSource.name}.yaml")
+            swaggerSource.code.outputDir = new File(project.buildDir, "swagger-code-${swaggerSource.name}")
+            swaggerSource.ui.outputDir = new File(project.buildDir, "swagger-ui-${swaggerSource.name}")
+        }
 
         project.afterEvaluate {
             project.tasks.withType(GenerateSwaggerCode) { task ->
                 GenerateSwaggerCodeHelp.injectHelpTaskFor(task)
             }
         }
+    }
+
+    private static createValidateSwagger(Project project, String sourceName = null) {
+        project.task("validateSwagger${sourceName ? sourceName.capitalize() : ''}",
+            type: ValidateSwagger,
+            group: 'verification',
+            description: "Validates YAML of ${sourceName ?: 'the OpenAPI specification'}.") as ValidateSwagger
+    }
+
+    private static createGenerateSwaggerCode(Project project, String sourceName = null) {
+        project.task("generateSwaggerCode${sourceName ? sourceName.capitalize() : ''}",
+            type: GenerateSwaggerCode,
+            group: 'build',
+            description: "Generates a source code from ${sourceName ?: 'the OpenAPI specification'}.",
+            dependsOn: 'resolveSwaggerTemplate') as GenerateSwaggerCode
+    }
+
+    private static createGenerateSwaggerUI(Project project, String sourceName = null) {
+        project.task("generateSwaggerUI${sourceName ? sourceName.capitalize() : ''}",
+            type: GenerateSwaggerUI,
+            group: 'documentation',
+            description: "Generates Swagger UI from ${sourceName ?: 'the OpenAPI specification'}.") as GenerateSwaggerUI
     }
 
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerSource.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/SwaggerSource.groovy
@@ -1,0 +1,44 @@
+package org.hidetake.gradle.swagger.generator
+
+import groovy.transform.ToString
+
+/**
+ * A domain model of Swagger source.
+ *
+ * @author Hidetake Iwata
+ */
+@ToString(includes = 'name', includePackage = false)
+class SwaggerSource {
+    final String name
+
+    def SwaggerSource(String name) {
+        this.name = name
+    }
+
+    GenerateSwaggerCode code
+
+    GenerateSwaggerCode code(@DelegatesTo(GenerateSwaggerCode) Closure closure) {
+        code.configure(closure)
+        code
+    }
+
+    GenerateSwaggerUI ui
+
+    GenerateSwaggerUI ui(@DelegatesTo(GenerateSwaggerUI) Closure closure) {
+        ui.configure(closure)
+        ui
+    }
+
+    ValidateSwagger validation
+
+    ValidateSwagger validation(@DelegatesTo(ValidateSwagger) Closure closure) {
+        validation.configure(closure)
+        validation
+    }
+
+    void setInputFile(File inputFile) {
+        code.inputFile = inputFile
+        ui.inputFile = inputFile
+        validation.inputFile = inputFile
+    }
+}

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy
@@ -18,7 +18,7 @@ class ValidateSwagger extends DefaultTask {
     File reportFile
 
     def ValidateSwagger() {
-        reportFile = new File(temporaryDir, 'report.yaml')
+        reportFile = new File(project.buildDir, 'swagger-validation.yaml')
     }
 
     @TaskAction
@@ -37,6 +37,7 @@ class ValidateSwagger extends DefaultTask {
             messages: validation*.asJson()
         )
 
+        reportFile.parentFile.mkdirs()
         reportFile.text = validationReport
 
         if (validation.success) {

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/SwaggerSourcesSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/SwaggerSourcesSpec.groovy
@@ -1,0 +1,41 @@
+package org.hidetake.gradle.swagger.generator
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class SwaggerSourcesSpec extends Specification {
+
+    def "plugin should add swaggerSources container"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.with {
+            apply plugin: 'org.hidetake.swagger.generator'
+        }
+
+        then:
+        project.extensions.findByName('swaggerSources') instanceof NamedDomainObjectContainer
+    }
+
+    def "swaggerSources container should have default values"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.with {
+            apply plugin: 'org.hidetake.swagger.generator'
+            swaggerSources {
+                foo {
+                    inputFile = file('foo.yaml')
+                }
+            }
+        }
+
+        then:
+        project.swaggerSources.foo.code.outputDir == new File(project.buildDir, 'swagger-code-foo')
+        project.swaggerSources.foo.ui.outputDir == new File(project.buildDir, 'swagger-ui-foo')
+    }
+
+}


### PR DESCRIPTION
This pull request allows declarative syntax for easily handling multiple sources.

```groovy
swaggerSources {
    petstoreV1 {
        inputFile = file('v1-petstore.yaml')
        code {
            language = 'spring'
            configFile = file('v1-config.json')
        }
    }
    petstoreV2 {
        inputFile = file('v2-petstore.yaml')
        code {
            language = 'spring'
            configFile = file('v2-config.json')
        }
    }
}
```