### PR TITLE
Add wipeOutputDir setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ Key           | Type              | Value                                   | De
 --------------|-------------------|-----------------------------------------|--------------
 `language`    | String            | Language to generate.                   | Mandatory
 `inputFile`   | File              | Swagger spec file.                      | Mandatory
-`outputDir`   | File              | Directory to write generated files, wiped before generation. Do not specify the project directory. | `$buildDir/swagger-code`
+`outputDir`   | File              | Directory to write generated files.     | `$buildDir/swagger-code`
+`wipeOutputDir` | Boolean         | Wipe the `outputDir` before generation. | `true`
 `library`     | String            | Library type.                           | None
 `configFile`  | File              | [JSON configuration file](https://github.com/swagger-api/swagger-codegen#customizing-the-generator). | None
 `templateDir` | File              | Directory containing the template.      | None
@@ -424,7 +425,8 @@ The task accepts below properties.
 Key           | Type              | Value                                   | Default value
 --------------|-------------------|-----------------------------------------|--------------
 `inputFile`   | File              | Swagger spec file.                      | Mandatory
-`outputDir`   | File              | Directory to write Swagger UI files, wiped before generation. Do not specify the project directory. | `$buildDir/swagger-ui`
+`outputDir`   | File              | Directory to write Swagger UI files.    | `$buildDir/swagger-ui`
+`wipeOutputDir` | Boolean         | Wipe the `outputDir` before generation. | `true`
 
 Note that `options` and `header` are no longer supported since 2.10.0.
 See the [Migration Guide](https://github.com/int128/gradle-swagger-generator-plugin/issues/81) for details.
@@ -437,7 +439,8 @@ The task accepts below properties.
 Key           | Type              | Value                                   | Default value
 --------------|-------------------|-----------------------------------------|--------------
 `inputFile`   | File              | Swagger spec file.                      | Mandatory
-`outputDir`   | File              | Directory to write ReDoc files, wiped before generation. Do not specify the project directory. | `$buildDir/swagger-redoc`
+`outputDir`   | File              | Directory to write ReDoc files.         | `$buildDir/swagger-redoc`
+`wipeOutputDir` | Boolean         | Wipe the `outputDir` before generation. | `true`
 `scriptSrc`   | String            | URL to ReDoc JavaScript.                | `//rebilly.github.io/ReDoc/releases/latest/redoc.min.js`
 `options`     | Map of Strings    | [ReDoc tag attributes](https://github.com/Rebilly/ReDoc#redoc-tag-attributes). | Empty map
 

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateReDoc.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateReDoc.groovy
@@ -18,6 +18,9 @@ class GenerateReDoc extends DefaultTask {
     File outputDir
 
     @Optional @Input
+    boolean wipeOutputDir = true
+
+    @Optional @Input
     String scriptSrc = '//rebilly.github.io/ReDoc/releases/latest/redoc.min.js'
 
     @Optional @Input
@@ -29,8 +32,6 @@ class GenerateReDoc extends DefaultTask {
 
     @TaskAction
     void exec() {
-        assert outputDir != project.projectDir, 'Prevent wiping the project directory'
-
         def html = Resources.withInputStream('/redoc.html') { inputStream ->
             new XmlParser(false, false, true).parse(inputStream)
         }
@@ -39,7 +40,10 @@ class GenerateReDoc extends DefaultTask {
         html.body.first().redoc.first().attributes().putAll(options)
         html.body.first().script.first().attributes().src = scriptSrc
 
-        project.delete(outputDir)
+        if (wipeOutputDir) {
+            assert outputDir != project.projectDir, 'Prevent wiping the project directory'
+            project.delete(outputDir)
+        }
         outputDir.mkdirs()
 
         new File(outputDir, 'index.html').withWriter { writer ->

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -20,6 +20,9 @@ class GenerateSwaggerCode extends DefaultTask {
     File outputDir
 
     @Optional @Input
+    boolean wipeOutputDir = true
+
+    @Optional @Input
     String library
 
     @Optional @InputFile
@@ -46,9 +49,11 @@ class GenerateSwaggerCode extends DefaultTask {
         assert language, "language should be set in the task $name"
         assert inputFile, "inputFile should be set in the task $name"
         assert outputDir, "outputDir should be set in the task $name"
-        assert outputDir != project.projectDir, 'Prevent wiping the project directory'
 
-        project.delete(outputDir)
+        if (wipeOutputDir) {
+            assert outputDir != project.projectDir, 'Prevent wiping the project directory'
+            project.delete(outputDir)
+        }
         outputDir.mkdirs()
 
         def args = buildOptions()

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUI.groovy
@@ -20,6 +20,9 @@ class GenerateSwaggerUI extends DefaultTask {
     @OutputDirectory
     File outputDir
 
+    @Optional @Input
+    boolean wipeOutputDir = true
+
     @Optional @Input @Deprecated
     Map<String, Object> options = [:]
 
@@ -40,8 +43,6 @@ class GenerateSwaggerUI extends DefaultTask {
                   }'''.stripIndent())
         }
 
-        assert outputDir != project.projectDir, 'Prevent wiping the project directory'
-
         // TODO: remove in the future release
         if (options) {
             log.warn('WARNING: GenerateSwaggerUI.options is no longer supported. See https://github.com/int128/gradle-swagger-generator-plugin/issues/81')
@@ -50,7 +51,10 @@ class GenerateSwaggerUI extends DefaultTask {
             log.warn('WARNING: GenerateSwaggerUI.header is no longer supported. See https://github.com/int128/gradle-swagger-generator-plugin/issues/81')
         }
 
-        project.delete(outputDir)
+        if (wipeOutputDir) {
+            assert outputDir != project.projectDir, 'Prevent wiping the project directory'
+            project.delete(outputDir)
+        }
         outputDir.mkdirs()
 
         extractWebJar()

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateReDocSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateReDocSpec.groovy
@@ -2,6 +2,7 @@ package org.hidetake.gradle.swagger.generator
 
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class GenerateReDocSpec extends Specification {
 
@@ -42,6 +43,35 @@ class GenerateReDocSpec extends Specification {
 
         then:
         project.tasks.generateReDoc.scriptSrc =~ /\.js$/
+    }
+
+    @Unroll
+    def 'task should #verb the output directory if wipeOutputDir == #wipe'() {
+        given:
+        def path = GenerateReDocSpec.getResource('/petstore-invalid.yaml').path
+        def project = ProjectBuilder.builder().build()
+        project.with {
+            apply plugin: 'org.hidetake.swagger.generator'
+            generateReDoc {
+                inputFile = file(path)
+                outputDir = buildDir
+                wipeOutputDir = wipe
+            }
+        }
+
+        project.buildDir.mkdirs()
+        def keep = new File(project.buildDir, 'keep') << 'something'
+
+        when:
+        project.tasks.generateReDoc.exec()
+
+        then:
+        keep.exists() == existence
+
+        where:
+        wipe    | verb      | existence
+        true    | 'wipe'    | false
+        false   | 'keep'    | true
     }
 
     def "exception should be thrown if projectDir is given"() {

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUISpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerUISpec.groovy
@@ -2,6 +2,7 @@ package org.hidetake.gradle.swagger.generator
 
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class GenerateSwaggerUISpec extends Specification {
 
@@ -43,6 +44,41 @@ class GenerateSwaggerUISpec extends Specification {
 
         then:
         thrown(IllegalStateException)
+    }
+
+    @Unroll
+    def 'task should #verb the output directory if wipeOutputDir == #wipe'() {
+        given:
+        def path = GenerateSwaggerUISpec.getResource('/petstore-invalid.yaml').path
+        def project = ProjectBuilder.builder().build()
+        project.with {
+            apply plugin: 'org.hidetake.swagger.generator'
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                swaggerUI 'org.webjars:swagger-ui:2.2.10'
+            }
+            generateSwaggerUI {
+                inputFile = file(path)
+                outputDir = buildDir
+                wipeOutputDir = wipe
+            }
+        }
+
+        project.buildDir.mkdirs()
+        def keep = new File(project.buildDir, 'keep') << 'something'
+
+        when:
+        project.tasks.generateSwaggerUI.exec()
+
+        then:
+        keep.exists() == existence
+
+        where:
+        wipe    | verb      | existence
+        true    | 'wipe'    | false
+        false   | 'keep'    | true
     }
 
     def "exception should be thrown if projectDir is given"() {


### PR DESCRIPTION
This pull request adds `wipeOutputDir` settings to tasks in order to keep an output directory. See also #43.