### PR TITLE
Create each tasks for acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           keys:
           - v1-dependencies-{{ checksum "build.gradle" }}
           - v1-dependencies-
-      - run: ./gradlew acceptance-test:buildDoc
+      - run: ./gradlew acceptance-test:build-doc-generator acceptance-test:build-doc-generator-swagger-ui-v2
       - run: ./.circleci/publish-gh-pages.sh
 
   release:

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -24,15 +24,12 @@ test {
     systemProperty 'current.gradle.version', gradle.gradleVersion
 }
 
-task buildDoc(type: JavaExec) {
-    classpath = sourceSets.test.runtimeClasspath
-    main = 'Main'
-    args = ['doc-generator', 'build']
+projectDir.eachDir { dir ->
+    if (file("$dir/build.gradle").exists()) {
+        project.task("build-${dir.name}", type: JavaExec, group: 'acceptance-test') {
+            classpath = sourceSets.test.runtimeClasspath
+            main = 'Main'
+            args = [dir.name, 'build']
+        }
+    }
 }
-
-task buildDocSwaggerUIv2(type: JavaExec) {
-    classpath = sourceSets.test.runtimeClasspath
-    main = 'Main'
-    args = ['doc-generator-swagger-ui-v2', 'build']
-}
-buildDoc.dependsOn buildDocSwaggerUIv2


### PR DESCRIPTION
This makes easy to run example projects.

```
Acceptance-test tasks
---------------------
build-blank-project
build-code-generator
build-custom-class
build-custom-template
build-doc-generator
build-doc-generator-swagger-ui-v2
build-externalize-class
build-externalize-template
build-multiple-sources
build-validator
```