### PR TITLE
Fix classloader issue

### DIFF
--- a/acceptance-test/code-generator-next/build.gradle
+++ b/acceptance-test/code-generator-next/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'base'
+    id 'org.hidetake.swagger.generator'
+}
+
+repositories {
+    jcenter()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+}
+
+dependencies {
+    swaggerCodegen 'io.swagger:swagger-codegen-cli:2.4.0-SNAPSHOT'
+}
+
+swaggerSources {
+    petstore {
+        inputFile = file("$buildDir/petstore.yaml")
+        code {
+            language = 'spring'
+            configFile = file('config.json')
+            components = ['models', 'apis']
+            dependsOn validation
+        }
+    }
+}
+
+build.dependsOn generateSwaggerCode

--- a/acceptance-test/code-generator-next/config.json
+++ b/acceptance-test/code-generator-next/config.json
@@ -1,0 +1,8 @@
+{
+  "library": "spring-mvc",
+  "dateLibrary": "java8",
+  "hideGenerationTimestamp": true,
+  "modelPackage": "example.model",
+  "apiPackage": "example.api",
+  "invokerPackage": "example"
+}

--- a/acceptance-test/externalize-class/build.gradle
+++ b/acceptance-test/externalize-class/build.gradle
@@ -11,6 +11,7 @@ repositories {
 }
 
 dependencies {
+    swaggerCodegen localGroovy()
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.3.1'
     swaggerCodegen 'org.hidetake:swagger-generators:1.0.0'
 }

--- a/acceptance-test/src/test/groovy/CodeGeneratorNextSpec.groovy
+++ b/acceptance-test/src/test/groovy/CodeGeneratorNextSpec.groovy
@@ -1,0 +1,64 @@
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+
+import static Fixture.cleanBuildDir
+import static Fixture.setupFixture
+
+class CodeGeneratorNextSpec extends Specification {
+
+    GradleRunner runner
+
+    def setup() {
+        runner = GradleRunner.create()
+            .withProjectDir(new File('code-generator-next'))
+            .withPluginClasspath()
+            .forwardOutput()
+        cleanBuildDir(runner)
+    }
+
+    def 'plugin should add default tasks into the project'() {
+        given:
+        runner.withArguments('--stacktrace', 'tasks')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.output.contains('generateSwaggerCode -')
+        result.output.contains('generateSwaggerCodeHelp -')
+    }
+
+    def 'generateSwaggerCode task should generate code'() {
+        given:
+        setupFixture(runner, Fixture.YAML.petstore)
+        runner.withArguments('--stacktrace', 'generateSwaggerCode')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        result.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.SUCCESS
+        new File(runner.projectDir, 'build/swagger-code-petstore/src/main/java/example/api/PetsApi.java').exists()
+
+        when:
+        def rerunResult = runner.build()
+
+        then:
+        rerunResult.task(':generateSwaggerCode').outcome == TaskOutcome.NO_SOURCE
+        rerunResult.task(':generateSwaggerCodePetstore').outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def 'generateSwaggerCodePetstoreHelp task should show help'() {
+        given:
+        runner.withArguments('--stacktrace', 'generateSwaggerCodePetstoreHelp')
+
+        when:
+        def result = runner.build()
+
+        then:
+        result.output.contains('CONFIG OPTIONS')
+    }
+
+}


### PR DESCRIPTION
This fixes #92 and possible #96.

It uses a dedicated class loader instead of one of the current Gradle project and prevents loading wrong classes.

It causes log level defaults to INFO because Gradle logger is no longer available in the new class loader, so sets the system property to adjust log level.
