### PR TITLE
Gradle 5.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 5.4 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/int128/gradle-swagger-generator-plugin/status for more.