### PR TITLE
Fix the incremental task "acceptance-test:test"

### DIFF
--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -71,3 +71,8 @@ task('example-docs', description: 'Generate example documents', group: 'document
         }
     }
 }
+
+
+test {
+  inputs.files fileTree(dir: "$project.projectDir/examples", excludes: ['**/.gradle', '**/build'])
+}


### PR DESCRIPTION
Hi

This pull request fixes improves the build script of the project.

Specifically, it fixes the incremental task `acceptance-test:test` so that Gradle re-executes tests whenever there are updates to any of the dependents files included in the `acceptance-test/examples` directory.

In the current situation, when there is an update to any of those files, I have to execute `./gradlew clean` in order to run acceptance tests again.