### PR TITLE
Fix Gradle warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ swaggerSources*.code*.dependsOn 'generators:jar'
 ```groovy
 // generators/build.gradle (child project)
 dependencies {
-  compile 'io.swagger:swagger-codegen-cli:2.4.2'
+  implementation 'io.swagger:swagger-codegen-cli:2.4.2'
 }
 ```
 

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'
     }
 }

--- a/acceptance-test/examples/codegen-v2/custom-class/generators/build.gradle
+++ b/acceptance-test/examples/codegen-v2/custom-class/generators/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'io.swagger:swagger-codegen-cli:2.4.2'
+    implementation localGroovy()
+    implementation 'io.swagger:swagger-codegen-cli:2.4.2'
 }

--- a/acceptance-test/examples/codegen-v2/externalize-class/generators/build.gradle
+++ b/acceptance-test/examples/codegen-v2/externalize-class/generators/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'io.swagger:swagger-codegen-cli:2.4.2'
+    implementation localGroovy()
+    implementation 'io.swagger:swagger-codegen-cli:2.4.2'
 }
 
 publishing {

--- a/acceptance-test/examples/codegen-v2/java-spring/build.gradle
+++ b/acceptance-test/examples/codegen-v2/java-spring/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
-    compile 'io.swagger:swagger-annotations:1.5.22'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    implementation 'io.swagger:swagger-annotations:1.5.22'
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.4.2'
 }
 

--- a/acceptance-test/examples/codegen-v3/custom-class/generators/build.gradle
+++ b/acceptance-test/examples/codegen-v3/custom-class/generators/build.gradle
@@ -8,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
+    implementation localGroovy()
+    implementation 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
 }

--- a/acceptance-test/examples/codegen-v3/externalize-class/generators/build.gradle
+++ b/acceptance-test/examples/codegen-v3/externalize-class/generators/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
+    implementation localGroovy()
+    implementation 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
 }
 
 publishing {

--- a/acceptance-test/examples/codegen-v3/java-spring/build.gradle
+++ b/acceptance-test/examples/codegen-v3/java-spring/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
-    compile 'io.swagger:swagger-annotations:1.5.22'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    implementation 'io.swagger:swagger-annotations:1.5.22'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
 }
 

--- a/acceptance-test/examples/openapi-v3/custom-class/generators/build.gradle
+++ b/acceptance-test/examples/openapi-v3/custom-class/generators/build.gradle
@@ -8,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'org.openapitools:openapi-generator-cli:3.3.4'
+    implementation localGroovy()
+    implementation 'org.openapitools:openapi-generator-cli:3.3.4'
 }

--- a/acceptance-test/examples/openapi-v3/externalize-class/generators/build.gradle
+++ b/acceptance-test/examples/openapi-v3/externalize-class/generators/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile 'org.openapitools:openapi-generator-cli:3.3.4'
+    implementation localGroovy()
+    implementation 'org.openapitools:openapi-generator-cli:3.3.4'
 }
 
 publishing {

--- a/acceptance-test/examples/openapi-v3/java-spring/build.gradle
+++ b/acceptance-test/examples/openapi-v3/java-spring/build.gradle
@@ -8,9 +8,9 @@ repositories {
 }
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
-    compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
-    compile 'io.springfox:springfox-swagger2:2.9.2'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    implementation 'io.swagger.core.v3:swagger-annotations:2.0.7'
+    implementation 'io.springfox:springfox-swagger2:2.9.2'
     swaggerCodegen 'org.openapitools:openapi-generator-cli:3.3.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'groovy'
-    id 'com.gradle.plugin-publish' version '0.9.7'
+    id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version '0.10.1'
 }
 
 java {
@@ -13,15 +14,15 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile 'com.github.fge:json-schema-validator:2.2.6'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.2.3'
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation 'com.github.fge:json-schema-validator:2.2.6'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.2.3'
 
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'
     }
-    testCompile 'cglib:cglib-nodep:3.2.10'
+    testRuntimeOnly 'cglib:cglib-nodep:3.2.10'
 }
 
 group = 'org.hidetake'
@@ -30,13 +31,16 @@ version = System.getenv('CIRCLE_TAG') ?: 'SNAPSHOT'
 pluginBundle {
     website = 'https://github.com/int128/gradle-swagger-generator-plugin'
     vcsUrl = 'https://github.com/int128/gradle-swagger-generator-plugin'
-    description = 'Gradle Swagger Generator Plugin'
     tags = ['swagger', 'api', 'generator']
+}
 
+gradlePlugin {
     plugins {
         swaggerPlugin {
             id = 'org.hidetake.swagger.generator'
             displayName = 'Gradle Swagger Generator Plugin'
+            description = 'Gradle plugin for OpenAPI YAML validation, code generation and API document publishing'
+            implementationClass = 'org.hidetake.gradle.swagger.generator.SwaggerGeneratorPlugin'
         }
     }
 }
@@ -45,7 +49,7 @@ allprojects {
     afterEvaluate {
         tasks.withType(Test) {
             finalizedBy ':testReport'
-            testReport.reportOn binResultsDir
+            testReport.reportOn binaryResultsDirectory
             reports.html.enabled = false
             reports.junitXml.destination = file("${rootProject.buildDir}/test-results")
         }

--- a/src/main/resources/META-INF/gradle-plugins/org.hidetake.swagger.generator.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.hidetake.swagger.generator.properties
@@ -1,1 +1,0 @@
-implementation-class=org.hidetake.gradle.swagger.generator.SwaggerGeneratorPlugin


### PR DESCRIPTION
This will fix Gradle build warnings. It will also move to `java-gradle-plugin` plugin as https://gradle.org/guides/?q=Plugin%20Development. See #185.