### PR TITLE
bump version to 2.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create a project with the following build script.
 
 ```groovy
 plugins {
-  id 'org.hidetake.swagger.generator' version '2.18.2'
+  id 'org.hidetake.swagger.generator' version '2.18.3'
 }
 
 repositories {
@@ -92,7 +92,7 @@ Create a project with the following build script.
 
 ```groovy
 plugins {
-  id 'org.hidetake.swagger.generator' version '2.18.2'
+  id 'org.hidetake.swagger.generator' version '2.18.3'
 }
 
 repositories {
@@ -125,7 +125,7 @@ Create a project with the following build script.
 
 ```groovy
 plugins {
-  id 'org.hidetake.swagger.generator' version '2.18.2'
+  id 'org.hidetake.swagger.generator' version '2.18.3'
 }
 
 swaggerSources {
@@ -150,7 +150,7 @@ Create a project with the following build script.
 
 ```groovy
 plugins {
-  id 'org.hidetake.swagger.generator' version '2.18.2'
+  id 'org.hidetake.swagger.generator' version '2.18.3'
 }
 
 repositories {

--- a/template-project/build.gradle
+++ b/template-project/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'org.hidetake.swagger.generator' version '2.18.2'
+    id 'org.hidetake.swagger.generator' version '2.18.3'
 }


### PR DESCRIPTION
Wanted to get OAS3 validateSwagger in the release version. Please let me know if the release version needs to be bumped to a different version.