### PR TITLE
Fix deprecation

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -68,7 +68,7 @@ class GenerateSwaggerCode extends DefaultTask {
         log.info("JavaExecOptions: $javaExecOptions")
         project.javaexec {
             classpath(javaExecOptions.classpath)
-            main = javaExecOptions.main
+            mainClass = javaExecOptions.main
             args = javaExecOptions.args
             systemProperties(javaExecOptions.systemProperties)
         }


### PR DESCRIPTION
setMain(String) is deprecated since Gradle 6.4. This replaces the call with getMainClass().set(String).
Note that this change breaks compatibility with Gradle < 6.4.