### PR TITLE
add jvmArgs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ Key           | Type              | Value                                   | De
 `additionalProperties` | Map of String, String | [Additional properties](https://github.com/swagger-api/swagger-codegen#to-generate-a-sample-client-library). | None
 `rawOptions`  | List of Strings   | Raw command line options for Swagger Codegen | None
 `configuration` | String or Configuration | Configuration for Swagger Codegen | `configurations.swaggerCodegen`
+`jvmArgs`     | List of Strings   | Arguments passed to jvm, example value: `['--add-opens=java.base/java.util=ALL-UNNAMED']`     | None
 
 
 ### Task type `GenerateSwaggerUI`

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,12 @@ plugins {
     id 'groovy'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.16.0'
-    id 'maven-publish'
 }
 
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,14 @@ plugins {
     id 'groovy'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.16.0'
+    id 'maven-publish'
 }
 
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCode.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.*
+import org.gradle.process.JavaExecSpec
 import org.hidetake.gradle.swagger.generator.codegen.AdaptorFactory
 import org.hidetake.gradle.swagger.generator.codegen.DefaultAdaptorFactory
 import org.hidetake.gradle.swagger.generator.codegen.GenerateOptions
@@ -53,6 +54,10 @@ class GenerateSwaggerCode extends DefaultTask {
 
     @Optional
     @Input
+    List<String> jvmArgs
+
+    @Optional
+    @Input
     def configuration
 
     @Internal
@@ -66,11 +71,12 @@ class GenerateSwaggerCode extends DefaultTask {
     void exec() {
         def javaExecOptions = execInternal()
         log.info("JavaExecOptions: $javaExecOptions")
-        project.javaexec {
-            classpath(javaExecOptions.classpath)
-            mainClass = javaExecOptions.main
-            args = javaExecOptions.args
-            systemProperties(javaExecOptions.systemProperties)
+        project.javaexec { JavaExecSpec c ->
+            c.classpath(javaExecOptions.classpath)
+            c.mainClass = javaExecOptions.main
+            c.args = javaExecOptions.args
+            c.systemProperties(javaExecOptions.systemProperties)
+            c.jvmArgs(javaExecOptions.jvmArgs ?: [])
         }
     }
 
@@ -95,6 +101,7 @@ class GenerateSwaggerCode extends DefaultTask {
             templateDir: templateDir?.path,
             additionalProperties: additionalProperties,
             rawOptions: rawOptions,
+            jvmArgs: this.jvmArgs,
             systemProperties: Helper.systemProperties(components),
         )
         log.info("GenerateOptions: $generateOptions")

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/GenerateSwaggerCodeHelp.groovy
@@ -30,6 +30,10 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
     @Input
     def configuration
 
+    @Optional
+    @Input
+    List<String> jvmArgs
+
     @Internal
     AdaptorFactory adaptorFactory = DefaultAdaptorFactory.instance
 
@@ -56,6 +60,7 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
         System.err.println("=== Available rawOptions ===")
         def helpOptions = new HelpOptions(
             generatorFiles: generatorFiles,
+            jvmArgs: this.jvmArgs
         )
         def helpJavaExecOptions = adaptor.help(helpOptions)
         log.info("JavaExecOptions: $helpJavaExecOptions")
@@ -64,12 +69,14 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
             c.main = helpJavaExecOptions.main
             c.args = helpJavaExecOptions.args
             c.systemProperties(helpJavaExecOptions.systemProperties)
+            c.jvmArgs(helpJavaExecOptions.jvmArgs ?: [])
         }
 
         System.err.println("=== Available JSON configuration for language $language ===")
         def configHelpOptions = new ConfigHelpOptions(
             generatorFiles: generatorFiles,
             language: language,
+            jvmArgs: this.jvmArgs
         )
         def configHelpJavaExecOptions = adaptor.configHelp(configHelpOptions)
         log.info("JavaExecOptions: $configHelpJavaExecOptions")
@@ -78,6 +85,7 @@ class GenerateSwaggerCodeHelp extends DefaultTask {
             c.main = configHelpJavaExecOptions.main
             c.args = configHelpJavaExecOptions.args
             c.systemProperties(configHelpJavaExecOptions.systemProperties)
+            c.jvmArgs(configHelpJavaExecOptions.jvmArgs ?: [])
         }
     }
 

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/ConfigHelpOptions.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/ConfigHelpOptions.groovy
@@ -9,4 +9,5 @@ import groovy.transform.Canonical
 class ConfigHelpOptions {
     Set<File> generatorFiles
     String language
+    List<String> jvmArgs
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/GenerateOptions.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/GenerateOptions.groovy
@@ -16,5 +16,6 @@ class GenerateOptions {
     String templateDir
     Map<String, String> additionalProperties
     List<String> rawOptions
+    List<String> jvmArgs
     Map<String, String> systemProperties
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/HelpOptions.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/HelpOptions.groovy
@@ -8,4 +8,5 @@ import groovy.transform.Canonical
 @Canonical
 class HelpOptions {
     Set<File> generatorFiles
+    List<String> jvmArgs
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/JavaExecOptions.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/JavaExecOptions.groovy
@@ -10,5 +10,6 @@ class JavaExecOptions {
     Set<File> classpath
     String main
     List<String> args
+    List<String> jvmArgs
     Map<String, String> systemProperties
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/OpenAPI3Adaptor.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/OpenAPI3Adaptor.groovy
@@ -44,6 +44,7 @@ class OpenAPI3Adaptor implements Adaptor {
             args: args,
             main: CLASS_NAME,
             systemProperties: systemProperties,
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -54,6 +55,7 @@ class OpenAPI3Adaptor implements Adaptor {
             args: ['help', 'generate'],
             main: CLASS_NAME,
             systemProperties: Helper.slf4jSimpleSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -64,6 +66,7 @@ class OpenAPI3Adaptor implements Adaptor {
             args: ['config-help', '-g', options.language],
             main: CLASS_NAME,
             systemProperties: Helper.slf4jSimpleSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger2Adaptor.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger2Adaptor.groovy
@@ -44,6 +44,7 @@ class Swagger2Adaptor implements Adaptor {
             args: args,
             main: CLASS_NAME,
             systemProperties: systemProperties,
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -54,6 +55,7 @@ class Swagger2Adaptor implements Adaptor {
             args: ['help', 'generate'],
             main: CLASS_NAME,
             systemProperties: Helper.slf4jSimpleSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -64,6 +66,7 @@ class Swagger2Adaptor implements Adaptor {
             args: ['config-help', '-l', options.language],
             main: CLASS_NAME,
             systemProperties: Helper.slf4jSimpleSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 }

--- a/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger3Adaptor.groovy
+++ b/src/main/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger3Adaptor.groovy
@@ -44,6 +44,7 @@ class Swagger3Adaptor implements Adaptor {
             args: args,
             main: CLASS_NAME,
             systemProperties: systemProperties,
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -54,6 +55,7 @@ class Swagger3Adaptor implements Adaptor {
             args: ['help', 'generate'],
             main: CLASS_NAME,
             systemProperties: Helper.logbackSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 
@@ -64,6 +66,7 @@ class Swagger3Adaptor implements Adaptor {
             args: ['config-help', '-l', options.language],
             main: CLASS_NAME,
             systemProperties: Helper.logbackSystemProperties(),
+            jvmArgs: options.jvmArgs,
         )
     }
 }

--- a/src/test/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger3AdaptorSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/swagger/generator/codegen/Swagger3AdaptorSpec.groovy
@@ -30,6 +30,7 @@ class Swagger3AdaptorSpec extends Specification {
                     language: 'java',
                     inputFile: 'input',
                     outputDir: 'output',
+                    jvmArgs: ['-Xmx1G']
                 ),
                 javaExecOptions: new JavaExecOptions(
                     classpath: [new File('foo.jar')],
@@ -40,6 +41,7 @@ class Swagger3AdaptorSpec extends Specification {
                         '-i', 'input',
                         '-o', 'output',
                     ],
+                    jvmArgs: ['-Xmx1G'],
                     systemProperties: ['logback.configurationFile': Helper.logbackXmlFile],
                 ),
             ),


### PR DESCRIPTION
This PR resolves  #221 - using this will allow this swaggergen to work with java versions higher than 15.

To use jdk > 15 - add this:

```
swaggerSources {
    myApi {
        inputFile = file("myApi.yaml")
        code {
            language = 'java'
            jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED']
        }        
    }
}
```